### PR TITLE
adding consuming external API's chapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+templates.md

--- a/mvc/app/url_mappings.go
+++ b/mvc/app/url_mappings.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-
 	"github.com/JonathanWamsley/courses/federico/intro-golang-microservices/mvc/controllers"
 )
 

--- a/mvc/utils/controller_utils.go
+++ b/mvc/utils/controller_utils.go
@@ -2,7 +2,7 @@ package utils
 
 import "github.com/gin-gonic/gin"
 
-func Respond(c *gin.Context ,status int, body interface{}) {
+func Respond(c *gin.Context, status int, body interface{}) {
 	if c.GetHeader("Accept") == "appliaction/xml" {
 		c.XML(status, body)
 		return
@@ -10,7 +10,7 @@ func Respond(c *gin.Context ,status int, body interface{}) {
 	c.JSON(status, body)
 }
 
-func RespondError(c *gin.Context , err *ApplicationError) {
+func RespondError(c *gin.Context, err *ApplicationError) {
 	if c.GetHeader("Accept") == "appliaction/xml" {
 		c.XML(err.StatusCode, err)
 		return

--- a/src/api/app/application.go
+++ b/src/api/app/application.go
@@ -1,0 +1,19 @@
+package app
+
+import "github.com/gin-gonic/gin"
+
+var (
+	router *gin.Engine
+)
+
+func init() {
+	router = gin.Default()
+}
+
+func StartApp() {
+	mapUrls()
+
+	if err := router.Run(":8080"); err != nil {
+		panic(err)
+	}
+}

--- a/src/api/app/url_mappings.go
+++ b/src/api/app/url_mappings.go
@@ -1,0 +1,11 @@
+package app
+
+import (
+	"github.com/JonathanWamsley/courses/federico/intro-golang-microservices/src/api/controllers/polo"
+	"github.com/JonathanWamsley/courses/federico/intro-golang-microservices/src/api/controllers/repositories"
+)
+
+func mapUrls() {
+	router.GET("/marco", polo.Marco)
+	router.POST("/repositories", repositories.CreateRepo)
+}

--- a/src/api/clients/restclient/restclient.go
+++ b/src/api/clients/restclient/restclient.go
@@ -1,0 +1,64 @@
+package restclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+var (
+	enabledMocks = false
+	mocks = make(map[string]*Mock)
+)
+
+type Mock struct {
+	Url string
+	HttpMethod string
+	Response *http.Response
+	Err error
+}
+
+func GetMockId(httpMethod string, url string) string {
+	return fmt.Sprintf("%s_%s", httpMethod, url)
+}
+
+func StartMockups() {
+	enabledMocks = true
+}
+
+func FlushMocks() {
+	mocks = make(map[string]*Mock)
+}
+
+func StopMockups() {
+	enabledMocks = false
+}
+
+func AddMockup(mock Mock) {
+	mocks[GetMockId(mock.HttpMethod, mock.Url)] = &mock
+}
+
+func Post(url string, body interface{}, headers http.Header) (*http.Response, error) {
+	if enabledMocks {
+		// return local mock without calling any external resource!
+		mock := mocks[GetMockId(http.MethodPost, url)]
+		if mock == nil {
+			return nil, errors.New("no mockup found for given request")
+		}
+		return mock.Response, mock.Err
+	}
+	jsonBytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	
+	
+	request, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(jsonBytes))
+	request.Header = headers
+
+	client := http.Client{}
+	response, err := client.Do(request)
+	return response, nil
+}

--- a/src/api/config/config.go
+++ b/src/api/config/config.go
@@ -1,0 +1,16 @@
+package config
+
+import "os"
+
+const(
+	// export SECRET_GITHUB_ACCESS_TOKEN=your_access_token
+	secretGithubAccessToken = "SECRET_GITHUB_ACCESS_TOKEN"
+)
+
+var(
+	githubAccessToken = os.Getenv(secretGithubAccessToken)
+)
+
+func GetGithubAccessToken() string {
+	return githubAccessToken
+}  

--- a/src/api/config/config_test.go
+++ b/src/api/config/config_test.go
@@ -1,0 +1,15 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TextConstants(t *testing.T) {
+	assert.EqualValues(t, "SECRET_GITHUB_ACCESS_TOKEN", secretGithubAccessToken)
+}
+
+func TestGetAccessToken(t *testing.T) {
+	assert.EqualValues(t, "", GetGithubAccessToken())
+}

--- a/src/api/controllers/polo/polo_controller.go
+++ b/src/api/controllers/polo/polo_controller.go
@@ -1,0 +1,15 @@
+package polo
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	polo = "polo"
+)
+
+func Marco(c *gin.Context) {
+	c.String(http.StatusOK, polo)
+}

--- a/src/api/controllers/polo/polo_controller_test.go
+++ b/src/api/controllers/polo/polo_controller_test.go
@@ -1,0 +1,25 @@
+package polo
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/JonathanWamsley/courses/federico/intro-golang-microservices/src/api/utils/test_utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConstants(t *testing.T) {
+	assert.EqualValues(t, "polo", polo)
+}
+
+func TestPolo(t *testing.T) {
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/marco", nil)
+	c := test_utils.GetMockedContext(request, response)
+
+	Marco(c)
+	assert.EqualValues(t, http.StatusOK, response.Code)
+	assert.EqualValues(t, "polo", response.Body.String())
+
+}

--- a/src/api/controllers/repositories/repositories_controller.go
+++ b/src/api/controllers/repositories/repositories_controller.go
@@ -1,0 +1,26 @@
+package repositories
+
+import (
+	"net/http"
+
+	"github.com/JonathanWamsley/courses/federico/intro-golang-microservices/src/api/domain/repositories"
+	"github.com/JonathanWamsley/courses/federico/intro-golang-microservices/src/api/services"
+	"github.com/JonathanWamsley/courses/federico/intro-golang-microservices/src/api/utils/errors"
+	"github.com/gin-gonic/gin"
+)
+
+func CreateRepo(c *gin.Context) {
+	var request repositories.CreateRepoRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		apiErr := errors.NewBadRequestApiError("invalid json body")
+		c.JSON((apiErr.Status()), apiErr)
+		return
+	}
+
+	result, err := services.RepositoryService.CreateRepo(request)
+	if err != nil {
+		c.JSON(err.Status(), err)
+		return
+	}
+	c.JSON(http.StatusCreated, result)
+}

--- a/src/api/controllers/repositories/repositories_controller_test.go
+++ b/src/api/controllers/repositories/repositories_controller_test.go
@@ -1,0 +1,93 @@
+package repositories
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/JonathanWamsley/courses/federico/intro-golang-microservices/src/api/clients/restclient"
+	"github.com/JonathanWamsley/courses/federico/intro-golang-microservices/src/api/domain/repositories"
+	"github.com/JonathanWamsley/courses/federico/intro-golang-microservices/src/api/utils/errors"
+	"github.com/JonathanWamsley/courses/federico/intro-golang-microservices/src/api/utils/test_utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	restclient.StartMockups()
+	os.Exit(m.Run())
+}
+
+func TestCreateRepoInvalidJsonRequet(t *testing.T) {
+	request, _ := http.NewRequest(http.MethodPost, "/repositories", strings.NewReader(``))
+	response := httptest.NewRecorder()
+	c := test_utils.GetMockedContext(request, response)
+
+	CreateRepo(c)
+
+	assert.EqualValues(t, http.StatusBadRequest, response.Code)
+	
+	apiErr, err := errors.NewApiErrFromBytes(response.Body.Bytes())
+	assert.Nil(t, err)
+	assert.NotNil(t, apiErr)
+	assert.EqualValues(t, http.StatusBadRequest, apiErr.Status())
+	assert.EqualValues(t, "invalid json body", apiErr.Message())
+}
+
+func TestCreateRepoErrorFromGithub(t *testing.T) {
+	restclient.FlushMocks()
+	restclient.AddMockup(restclient.Mock{
+		Url: "https://api.github.com/user/repos",
+		HttpMethod: http.MethodPost,
+		Response: &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Body: ioutil.NopCloser(strings.NewReader(`{"message": "Requires authentication",
+				"documentation_url": "https://docs.github.com/rest/reference/repos#create-a-repository-for-the-authenticated-user"}`)),
+		},
+	})
+
+	response := httptest.NewRecorder()
+	request, _ := http.NewRequest(http.MethodPost, "/repositories", strings.NewReader(`{"name": "testing"}`))
+	c := test_utils.GetMockedContext(request, response)
+
+	CreateRepo(c)
+
+	assert.EqualValues(t, http.StatusUnauthorized, response.Code)
+	
+	apiErr, err := errors.NewApiErrFromBytes(response.Body.Bytes())
+	assert.Nil(t, err)
+	assert.NotNil(t, apiErr)
+	assert.EqualValues(t, http.StatusUnauthorized, apiErr.Status())
+	assert.EqualValues(t, "Requires authentication", apiErr.Message())
+}
+
+func TestCreateRepoNoError(t *testing.T) {
+	response := httptest.NewRecorder()
+	request, _ := http.NewRequest(http.MethodPost, "/repositories", strings.NewReader(`{"name": "testing"}`))
+	c := test_utils.GetMockedContext(request, response)
+
+
+	restclient.FlushMocks()
+	restclient.AddMockup(restclient.Mock{
+		Url: "https://api.github.com/user/repos",
+		HttpMethod: http.MethodPost,
+		Response: &http.Response{
+			StatusCode: http.StatusCreated,
+			Body: ioutil.NopCloser(strings.NewReader(`{"id": 123}`)),
+		},
+	})
+
+	CreateRepo(c)
+
+	assert.EqualValues(t, http.StatusCreated, response.Code)
+	
+	var result repositories.CreateRepoResponse
+	err := json.Unmarshal(response.Body.Bytes(), &result)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 123, result.Id)
+	assert.EqualValues(t, "", result.Name)
+	assert.EqualValues(t, "", result.Owner)
+}

--- a/src/api/domain/github/create_repo.go
+++ b/src/api/domain/github/create_repo.go
@@ -1,0 +1,42 @@
+package github
+
+// {
+//     "name": "git repo",
+//     "description": "Testing github api",
+//     "homepage": "https://github.com",
+//     "private": false,
+//     "has_issues": true,
+//     "has_projects": true,
+//     "has_wiki": true
+// }
+
+type CreateRepoRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Homepage    string `json:"homepage"`
+	Private     bool   `json:"private"`
+	HasIssues   bool   `json:"has_issues"`
+	HasProjects bool   `json:"has_projects"`
+	HasWiki     bool   `json:"has_wiki"`
+}
+
+type CreateRepoResponse struct {
+	Id          int64           `json:"id"`
+	Name        string          `json:"name"`
+	FullName    string          `json:"full_name"`
+	Owner       RepoOwner       `json:"owner"`
+	Permissions RepoPermissions `json:"permissions"`
+}
+
+type RepoOwner struct {
+	Id      int64  `json:"id"`
+	Login   string `json:"login"`
+	Url     string `json:"url"`
+	HtmlUrl string `json:"html_url"`
+}
+
+type RepoPermissions struct {
+	IsAdmid bool `json:"admin"`
+	HasPull bool `json:"push"`
+	HasPush bool `json:"pull"`
+}

--- a/src/api/domain/github/create_repo_test.go
+++ b/src/api/domain/github/create_repo_test.go
@@ -1,0 +1,39 @@
+package github
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateRepoRequestAsJson(t *testing.T) {
+	request := CreateRepoRequest{
+		Name:        "git repo",
+		Description: "Testing github api",
+		Homepage:    "https://github.com",
+		Private:     true,
+		HasIssues:   false,
+		HasProjects: true,
+		HasWiki:     false,
+	}
+
+	bytes, err := json.Marshal(request)
+	assert.Nil(t, err)
+	assert.NotNil(t, bytes)
+
+
+	var target CreateRepoRequest
+
+	// Unmarshal takes an input byte aray and a *pointer that we're trying to fill using this json
+	err = json.Unmarshal(bytes, &target)
+	assert.Nil(t, err)
+	
+	assert.EqualValues(t, target.Name, request.Name)
+	assert.EqualValues(t, target.Description, request.Description)
+	assert.EqualValues(t, target.Homepage, request.Homepage)
+	assert.EqualValues(t, target.Private, request.Private)
+	assert.EqualValues(t, target.HasIssues, request.HasIssues)
+	assert.EqualValues(t, target.HasProjects, request.HasProjects)
+	assert.EqualValues(t, target.HasWiki, request.HasWiki)
+}

--- a/src/api/domain/github/github_error.go
+++ b/src/api/domain/github/github_error.go
@@ -1,0 +1,15 @@
+package github
+
+type GithubErrorResponse struct {
+	StatusCode       int           `json:"status_code"`
+	Message          string        `json:"message"`
+	DocumentationUrl string        `json:"documentation_url"`
+	Errors           []GithubError `json:"errors"`
+}
+
+type GithubError struct {
+	Resource string `json:"resource"`
+	Code     string `json:"code"`
+	Field    string `json:"field"`
+	Message  string `json:"message"`
+}

--- a/src/api/domain/repositories/create_repo.go
+++ b/src/api/domain/repositories/create_repo.go
@@ -1,0 +1,12 @@
+package repositories
+
+type CreateRepoRequest struct {
+	Name	 string	 `json:"name"`
+	Description	 string	 `json:"description"`
+}
+
+type CreateRepoResponse struct {
+	Id	 int64	 `json:"id"`
+	Owner	 string	 `json:"owner"`
+	Name	 string	 `json:"name"`
+}

--- a/src/api/main.go
+++ b/src/api/main.go
@@ -1,0 +1,9 @@
+package main
+
+import "github.com/JonathanWamsley/courses/federico/intro-golang-microservices/src/api/app"
+
+
+
+func main() {
+	app.StartApp()
+}

--- a/src/api/providers/github_provider/github_provider.go
+++ b/src/api/providers/github_provider/github_provider.go
@@ -1,0 +1,70 @@
+package github_provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"log"
+	"net/http"
+
+	"github.com/JonathanWamsley/courses/federico/intro-golang-microservices/src/api/clients/restclient"
+	"github.com/JonathanWamsley/courses/federico/intro-golang-microservices/src/api/domain/github"
+)
+
+const (
+	headerAuthorization       = "Authorization"
+	headerAuthorizationFormat = "token %s"
+
+	urlCreateRepo = "https://api.github.com/user/repos"
+)
+
+func getAuthorizationHeader(accessToken string) string {
+	return fmt.Sprintf(headerAuthorizationFormat, accessToken)
+}
+
+func CreateRepo(accessToken string, request github.CreateRepoRequest) (*github.CreateRepoResponse, *github.GithubErrorResponse) {
+	header := getAuthorizationHeader(accessToken)
+	headers := http.Header{}
+	headers.Set(headerAuthorization, header)
+	response, err := restclient.Post(urlCreateRepo, request, headers)
+	if err != nil {
+		log.Println(fmt.Sprintf("error when trying to create new repo in github: %s", err.Error()))
+		return nil, &github.GithubErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    err.Error(),
+		}
+	}
+
+	bytes, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, &github.GithubErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    "invalid response body",
+		}
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode > 299 {
+		var errResponse github.GithubErrorResponse
+		if err := json.Unmarshal(bytes, &errResponse); err != nil {
+			return nil, &github.GithubErrorResponse{
+				StatusCode: http.StatusInternalServerError,
+				Message:    "invalid json response body",
+			}
+		}
+		errResponse.StatusCode = response.StatusCode
+		return nil, &errResponse
+	}
+
+	var result github.CreateRepoResponse
+	if err := json.Unmarshal(bytes, &result); err != nil {
+		log.Println(fmt.Sprintf("error when trying to unmarshal create repo successful response %s", err.Error()))
+		return nil, &github.GithubErrorResponse{
+			StatusCode: http.StatusInternalServerError,
+			Message:    "error when trying to unmarshalling github create repo response",
+		}
+	}
+
+	return &result, nil
+}

--- a/src/api/providers/github_provider/github_provider_test.go
+++ b/src/api/providers/github_provider/github_provider_test.go
@@ -1,0 +1,140 @@
+package github_provider
+
+import (
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/JonathanWamsley/courses/federico/intro-golang-microservices/src/api/clients/restclient"
+	"github.com/JonathanWamsley/courses/federico/intro-golang-microservices/src/api/domain/github"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	restclient.StartMockups()
+	os.Exit(m.Run())
+}
+
+func TestConstants(t *testing.T) {
+	assert.EqualValues(t, "Authorization", headerAuthorization)
+	assert.EqualValues(t, "token %s", headerAuthorizationFormat)
+	assert.EqualValues(t, "https://api.github.com/user/repos", urlCreateRepo)
+}
+
+func TestGetAuthorizationHeader(t *testing.T) {
+	header := getAuthorizationHeader("abc123")
+	assert.EqualValues(t, "token abc123", header)
+}
+
+func TestCreateRepoErrorRestclient(t *testing.T) {
+	restclient.FlushMocks()
+	restclient.AddMockup(restclient.Mock{
+		Url: "https://api.github.com/user/repos",
+		HttpMethod: http.MethodPost,
+		Err: errors.New("invalid restclient response"),
+	})
+
+	response, err := CreateRepo("", github.CreateRepoRequest{})
+	assert.Nil(t, response)
+	assert.NotNil(t, err)
+	assert.EqualValues(t, http.StatusInternalServerError, err.StatusCode)
+	assert.EqualValues(t, "invalid restclient response", err.Message)
+}
+
+
+func TestCreateRepoInvalidResponseBody(t *testing.T) {
+	restclient.FlushMocks()
+	invalidCloser, _ := os.Open("-asf3")
+	restclient.AddMockup(restclient.Mock{
+		Url: "https://api.github.com/user/repos",
+		HttpMethod: http.MethodPost,
+		Response: &http.Response{
+			StatusCode: http.StatusCreated,
+			Body: invalidCloser,
+		},
+	})
+
+	response, err := CreateRepo("", github.CreateRepoRequest{})
+	assert.Nil(t, response)
+	assert.NotNil(t, err)
+	assert.EqualValues(t, http.StatusInternalServerError, err.StatusCode)
+	assert.EqualValues(t, "invalid response body", err.Message)
+}
+
+func TestCreateRepoInvalidErrorInterface(t *testing.T) {
+	restclient.FlushMocks()
+	restclient.AddMockup(restclient.Mock{
+		Url: "https://api.github.com/user/repos",
+		HttpMethod: http.MethodPost,
+		Response: &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Body: ioutil.NopCloser(strings.NewReader(`{"message": 1}`)),
+		},
+	})
+
+	response, err := CreateRepo("", github.CreateRepoRequest{})
+	assert.Nil(t, response)
+	assert.NotNil(t, err)
+	assert.EqualValues(t, http.StatusInternalServerError, err.StatusCode)
+	assert.EqualValues(t, "invalid json response body", err.Message)
+}
+
+func TestCreateRepoUnauthorized(t *testing.T) {
+	restclient.FlushMocks()
+	restclient.AddMockup(restclient.Mock{
+		Url: "https://api.github.com/user/repos",
+		HttpMethod: http.MethodPost,
+		Response: &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Body: ioutil.NopCloser(strings.NewReader(`{"message": "Requires authentication",
+				"documentation_url": "https://docs.github.com/rest/reference/repos#create-a-repository-for-the-authenticated-user"}`)),
+		},
+	})
+
+	response, err := CreateRepo("", github.CreateRepoRequest{})
+	assert.Nil(t, response)
+	assert.NotNil(t, err)
+	assert.EqualValues(t, http.StatusUnauthorized, err.StatusCode)
+	assert.EqualValues(t, "Requires authentication", err.Message)
+}
+
+func TestCreateRepoInvalidSuccessResponse(t *testing.T) {
+	restclient.FlushMocks()
+	restclient.AddMockup(restclient.Mock{
+		Url: "https://api.github.com/user/repos",
+		HttpMethod: http.MethodPost,
+		Response: &http.Response{
+			StatusCode: http.StatusCreated,
+			Body: ioutil.NopCloser(strings.NewReader(`{"id": "123"}`)),
+		},
+	})
+
+	response, err := CreateRepo("", github.CreateRepoRequest{})
+	assert.Nil(t, response)
+	assert.NotNil(t, err)
+	assert.EqualValues(t, http.StatusInternalServerError, err.StatusCode)
+	assert.EqualValues(t, "error when trying to unmarshalling github create repo response", err.Message)
+}
+
+func TestCreateRepoNoError(t *testing.T) {
+	restclient.FlushMocks()
+	restclient.AddMockup(restclient.Mock{
+		Url: "https://api.github.com/user/repos",
+		HttpMethod: http.MethodPost,
+		Response: &http.Response{
+			StatusCode: http.StatusCreated,
+			Body: ioutil.NopCloser(strings.NewReader(`{"id": 123, "name": "git repo", "full_name": "test_name"}`)),
+		},
+	})
+
+	response, err := CreateRepo("", github.CreateRepoRequest{})
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.EqualValues(t, 123, response.Id)
+	assert.EqualValues(t, "git repo", response.Name)
+	assert.EqualValues(t, "test_name", response.FullName)
+	
+}

--- a/src/api/providers/main.go
+++ b/src/api/providers/main.go
@@ -1,0 +1,1 @@
+package main

--- a/src/api/services/repositories_service.go
+++ b/src/api/services/repositories_service.go
@@ -1,0 +1,50 @@
+package services
+
+import (
+	"strings"
+
+	"github.com/JonathanWamsley/courses/federico/intro-golang-microservices/src/api/config"
+	"github.com/JonathanWamsley/courses/federico/intro-golang-microservices/src/api/domain/github"
+	"github.com/JonathanWamsley/courses/federico/intro-golang-microservices/src/api/domain/repositories"
+	"github.com/JonathanWamsley/courses/federico/intro-golang-microservices/src/api/providers/github_provider"
+	"github.com/JonathanWamsley/courses/federico/intro-golang-microservices/src/api/utils/errors"
+)
+
+type repoService struct{}
+
+type repoServiceInterface interface{
+	CreateRepo(request repositories.CreateRepoRequest) (*repositories.CreateRepoResponse, errors.ApiError)
+}
+
+var(
+	RepositoryService repoServiceInterface
+)
+
+func init() {
+	RepositoryService = &repoService{}
+}
+
+func (s *repoService) CreateRepo(input repositories.CreateRepoRequest) (*repositories.CreateRepoResponse, errors.ApiError) {
+	input.Name = strings.TrimSpace(input.Name)
+	if input.Name == "" {
+		return nil, errors.NewBadRequestApiError("invalid repository name")
+	}
+
+	request := github.CreateRepoRequest{
+		 Name: input.Name,
+		 Description: input.Description,
+		 Private: false,
+	}
+
+	response, err := github_provider.CreateRepo(config.GetGithubAccessToken(), request)
+	if err != nil {
+		return nil, errors.NewApiError(err.StatusCode, err.Message)
+	}
+
+	result := repositories.CreateRepoResponse {
+		Id: response.Id,
+		Name: response.Name,
+		Owner: response.Owner.Login,
+	}
+	return &result, nil
+}

--- a/src/api/services/repositories_services_test.go
+++ b/src/api/services/repositories_services_test.go
@@ -1,0 +1,76 @@
+package services
+
+import (
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/JonathanWamsley/courses/federico/intro-golang-microservices/src/api/clients/restclient"
+	"github.com/JonathanWamsley/courses/federico/intro-golang-microservices/src/api/domain/repositories"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	restclient.StartMockups()
+	os.Exit(m.Run())
+}
+
+func TestCreateRepoInvalidName(t *testing.T) {
+	request := repositories.CreateRepoRequest{
+		Name: "",
+		Description: "test description",
+	}
+
+	result, err := RepositoryService.CreateRepo(request)
+	assert.Nil(t, result)
+	assert.NotNil(t, err)
+	assert.EqualValues(t, "invalid repository name", err.Message())
+	assert.EqualValues(t, http.StatusBadRequest, err.Status())
+}
+
+func TestCreateRepoIErrorFromGithub(t *testing.T) {
+	restclient.FlushMocks()
+	restclient.AddMockup(restclient.Mock{
+		Url: "https://api.github.com/user/repos",
+		HttpMethod: http.MethodPost,
+		Response: &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Body: ioutil.NopCloser(strings.NewReader(`{"message": "Requires authentication",
+				"documentation_url": "https://docs.github.com/rest/reference/repos#create-a-repository-for-the-authenticated-user"}`)),
+		},
+	})
+
+	request := repositories.CreateRepoRequest{
+		Name: "test name",
+		Description: "test description",
+	}
+
+	result, err := RepositoryService.CreateRepo(request)
+	assert.Nil(t, result)
+	assert.NotNil(t, err)
+	assert.EqualValues(t, "Requires authentication", err.Message())
+	assert.EqualValues(t, http.StatusUnauthorized, err.Status())
+}
+
+func TestCreateRepoNoError(t *testing.T) {
+	restclient.FlushMocks()
+	restclient.AddMockup(restclient.Mock{
+		Url: "https://api.github.com/user/repos",
+		HttpMethod: http.MethodPost,
+		Response: &http.Response{
+			StatusCode: http.StatusCreated,
+			Body: ioutil.NopCloser(strings.NewReader(`{"id": 123, "name": "test name", "owner": {"login": "login owner"}}`)),
+		},
+	})
+
+	request := repositories.CreateRepoRequest{Name: "test name"}
+
+	result, err := RepositoryService.CreateRepo(request)
+	assert.Nil(t, err)
+	assert.NotNil(t, result)	
+	assert.EqualValues(t, 123, result.Id)
+	assert.EqualValues(t, "test name", result.Name)
+	assert.EqualValues(t, "login owner", result.Owner)
+}

--- a/src/api/utils/errors/errors.go
+++ b/src/api/utils/errors/errors.go
@@ -1,0 +1,67 @@
+package errors
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+)
+
+type ApiError interface {
+	Status() int
+	Message() string
+	Error() string
+}
+
+type apiError struct {
+	AStatus	 int	 `json:"status"`
+	AMessage	 string	 `json:"message"`
+	AnError	 string	 `json:"error"`
+}
+
+func (e *apiError) Status() int {
+	return e.AStatus
+}
+
+func (e *apiError) Message() string {
+	return e.AMessage
+}
+
+func (e *apiError) Error() string {
+	return e.AnError
+}
+
+func NewApiError(statusCode int, message string) ApiError {
+	return &apiError{
+		AStatus: statusCode,
+		AMessage: message,
+	}
+}
+
+func NewApiErrFromBytes(body []byte) (*apiError, error) {
+	var result apiError
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, errors.New("invalid json for creatting an api error")
+	}
+	return &result, nil
+}
+
+func NewNotFoundApiError(message string) ApiError {
+	return &apiError{
+		AStatus: http.StatusNotFound,
+		AMessage: message,
+	}
+}
+
+func NewInternalServerError(message string) ApiError {
+	return &apiError{
+		AStatus: http.StatusInternalServerError,
+		AMessage: message,
+	}
+}
+
+func NewBadRequestApiError(message string) ApiError {
+	return &apiError{
+		AStatus: http.StatusBadRequest,
+		AMessage: message,
+	}
+}

--- a/src/api/utils/test_utils/test_utils.go
+++ b/src/api/utils/test_utils/test_utils.go
@@ -1,0 +1,14 @@
+package test_utils
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/gin-gonic/gin"
+)
+
+func GetMockedContext(request *http.Request, response *httptest.ResponseRecorder) *gin.Context {
+	c, _ := gin.CreateTestContext(response)
+	c.Request = request
+	return c
+}

--- a/src/api/utils/test_utils/test_utils_test.go
+++ b/src/api/utils/test_utils/test_utils_test.go
@@ -1,0 +1,25 @@
+package test_utils
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMockedContext(t *testing.T) {
+	request, err := http.NewRequest(http.MethodGet, "http://localhost:123/something", nil)
+	assert.Nil(t, err)
+	response := httptest.NewRecorder()
+	request.Header = http.Header{"X-Mock": {"true"}}
+	c := GetMockedContext(request, response)
+
+	assert.EqualValues(t, http.MethodGet, c.Request.Method)
+	assert.EqualValues(t, "123", c.Request.URL.Port())
+	assert.EqualValues(t, "/something", c.Request.URL.Path)
+	assert.EqualValues(t, "http", c.Request.URL.Scheme)
+	assert.EqualValues(t, 1, len(c.Request.Header))
+	assert.EqualValues(t, "true", c.GetHeader("X-Mock"))
+	assert.EqualValues(t, "true", c.GetHeader("x-mock"))
+}


### PR DESCRIPTION
adding consuming external API's chapter that covers creating a github repo api with tests